### PR TITLE
Containerise acobot

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,42 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+
+env:
+  IMAGE_NAME: acobot
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate version timestamp
+        id: prep
+        run: |
+          ts=$(date "+%Y%m%d-%H%M%S")
+          echo "BUILD_VER=${ts}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ steps.prep.outputs.BUILD_VER }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest

--- a/Docker_readme.txt
+++ b/Docker_readme.txt
@@ -1,0 +1,16 @@
+# To build a new docker image
+
+$ docker build -t yourname/acobot:latest .
+
+# To run in a container
+
+Make a local dir to store your .env and database files
+
+$ mkdir /opt/acobot
+$ cp .env /opt/acobot
+$ cp .ptnuserdata.json /opt/acobot
+$ mkdir /opt/acobot/dumps
+
+Run the container:
+
+$ docker run -d --restart unless-stopped --name acobot -v /opt/acobot:/root/acobot yourname/acobot:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-slim-buster
+RUN mkdir -p /usr/src/bot
+WORKDIR /usr/src/bot
+COPY setup.py .
+COPY README.md .
+COPY ptn ptn
+RUN pip3 install .
+RUN mkdir /root/acobot
+RUN ln -s /root/acobot/.ptnuserdata.json /root/.ptnuserdata.json
+RUN ln -s /root/acobot/.env /root/.env
+WORKDIR /root/acobot
+ENTRYPOINT ["/usr/local/bin/aco"]

--- a/ptn/aco/constants.py
+++ b/ptn/aco/constants.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv, find_dotenv
 
 # Get the discord token from the local .env file. Deliberately not hosted in the repo or Discord takes the bot down
 # because the keys are exposed. DO NOT HOST IN THE REPO. Seriously do not do it ...
-load_dotenv(find_dotenv())
+load_dotenv(find_dotenv(usecwd=True))
 
 PROD_DISCORD_GUILD = 800080948716503040  # PTN Discord server
 PROD_DB_PATH = os.path.join(os.path.expanduser('~'), 'acobot', 'aco_applications.db')

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
     author='Graeme Cruickshank',
     url='',
     install_requires=[
-        'discord',
-        'discord-py-slash-command',
+        'discord.py==1.7.3',
+        'discord-py-slash-command==3.0.3',
         'google-api-python-client',
         'gspread',
         'oauth2client',


### PR DESCRIPTION
.github/workflows/container.yml - builds the container on pushes to "main" branch only.

Docker_readme.txt - instructions for locally building and running acobot in a container for testing

Dockerfile - the docker container build instructions

ptn/aco/constants.py - add `usecwd=True` to `find_dotenv()` to correctly find the file in the container CWD.

setup.py - lock versions of discord.py and discord-py-slash-command. rename `discord` to `discord.py` as it was incorrect.